### PR TITLE
chore: release v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/samkeen/vec-embed-store/compare/v0.1.1...v0.1.2) - 2024-05-17
+
+### Other
+- update changelog
+
 ### Added
 
 ## [0.1.1](https://github.com/samkeen/vec-embed-store/compare/v0.1.0...v0.1.1) - 2024-05-17

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4444,7 +4444,7 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vec-embed-store"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "arrow-array",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vec-embed-store"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 description = "This is a thin wrapper around LanceDb (VectorDb) meant to provide a means to create/store/query embeddings in a LanceDb without the need to grok the lower level Arrow/ColumnarDb tech."
 license = "Apache-2.0"


### PR DESCRIPTION
## 🤖 New release
* `vec-embed-store`: 0.1.1 -> 0.1.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.2](https://github.com/samkeen/vec-embed-store/compare/v0.1.1...v0.1.2) - 2024-05-17

### Other
- update changelog

### Added
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).