### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/samkeen/vec-embed-store/compare/v0.1.1...v0.2.0) - 2024-05-18
+
+### Added
+- Now support all FastEmbed models
+
 ### Added
 
 ## [0.1.1](https://github.com/samkeen/vec-embed-store/compare/v0.1.0...v0.1.1) - 2024-05-17

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4444,7 +4444,7 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vec-embed-store"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "arrow-array",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vec-embed-store"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 description = "This is a thin wrapper around LanceDb (VectorDb) meant to provide a means to create/store/query embeddings in a LanceDb without the need to grok the lower level Arrow/ColumnarDb tech."
 license = "Apache-2.0"


### PR DESCRIPTION
## 🤖 New release
* `vec-embed-store`: 0.1.1 -> 0.2.0 (⚠️ API breaking changes)

### ⚠️ `vec-embed-store` breaking changes

```
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.31.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field EmbeddingEngineOptions.model_name in /tmp/.tmpjtNh9T/vec-embed-store/src/lib.rs:122

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.31.0/src/lints/enum_variant_added.ron

Failed in:
  variant EmbedDbError:Config in /tmp/.tmpjtNh9T/vec-embed-store/src/lib.rs:392
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.0](https://github.com/samkeen/vec-embed-store/compare/v0.1.1...v0.2.0) - 2024-05-18

### Added
- Now support all FastEmbed models

### Added
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).