### PR TITLE
fix: refactoring to interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,60 +3,98 @@
 This is a thin wrapper around LanceDb (VectorDb) meant to provide a means to create/store/query
 embeddings in a LanceDb without the need to grok the lower level Arrow/ColumnarDb tech.
 
-# Usage example
+## Usage example
+
+Add VecEmbedStore to dependencies
+
+```bash
+cargo add vec_embed_store
+# If you want to select a Embedding engine other than the default, you currently need to add fastembed 
+# This is an issue open to remove this requirement: https://github.com/samkeen/vec-embed-store/issues/9
+# [optional] 
+cargo add fastembed
+
+```
 
 ```rust
-fn main() {
+use std::path::PathBuf;
+use vec_embed_store::{EmbeddingsDb, EmbeddingEngineOptions, TextChunk, SimilaritySearch};
+use fastembed::EmbeddingModel::BGESmallENV15;
 
-    // Instance EmbeddingsDb
-    let db_dir_path = "db";
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Set up the embedding engine options, 
     let embedding_engine_options = EmbeddingEngineOptions {
-        model_name: EmbeddingModel::BGESmallENV15,
+        model_name: BGESmallENV15, // see https://docs.rs/fastembed/latest/fastembed/enum.EmbeddingModel.html
+        cache_dir: PathBuf::from("path/to/cache"),
+        show_download_progress: true,
         ..Default::default()
     };
-    let embed_db = EmbeddingsDb::new(db_dir_path, embedding_engine_options).await.unwrap();
 
-    // Add documents
-    let documents = vec![
-        TextBlock {
+    // Create a new instance of EmbeddingsDb
+    let embed_db = EmbeddingsDb::new("path/to/db", embedding_engine_options).await?;
+
+    // Define the texts to be added to the database.  Chunk texts in any way you see fit (and matches with the 
+    //   chosen embedding engine).
+    let texts = vec![
+        TextChunk {
             id: "1".to_string(),
-            text: "Hello world".to_string(),
+            text: "Once upon a midnight dreary, while I pondered, weak and weary,".to_string(),
         },
-        TextBlock {
+        TextChunk {
             id: "2".to_string(),
-            text: "Rust programming".to_string(),
+            text: "Over many a quaint and curious volume of forgotten lore—".to_string(),
+        },
+        TextChunk {
+            id: "3".to_string(),
+            text: "While I nodded, nearly napping, suddenly there came a tapping,".to_string(),
         },
     ];
-    embed_db.add_texts(texts).await.unwrap();
 
-    // check for similarities for a given document
-    let search_doc = TextBlock {
-        id: "3".to_string(),
-        text: "Hello world".to_string(),
-    };
-    let result: Vec<ComparedTextBlock> = embed_db
-        .get_similar_to(search_doc.clone())
-        //.threshold(0.001) // Optional minimum distance for vector distance comparisons
-        //.limit(10)        // Optional limit number items returned
+    // Upsert the texts into the embeddings database (there is no separate add/update)
+    // TextChunks MUST be unique on `TextChunk.id`
+    embed_db.upsert_texts(&texts).await?;
+
+    // Retrieve a text by its ID
+    let retrieved_text = embed_db.get_text_by_id("1").await?;
+    println!("Retrieved text: {:?}", retrieved_text);
+
+    // Define a text for similarity search
+    let search_text = "suddenly there came a tapping";
+
+    // Perform a similarity search
+    let search_results = embed_db
+        .get_similar_to(search_text)
+        .limit(2)
+        .threshold(0.8)
         .execute()
-        .await
-        .unwrap();
+        .await?;
 
-    dbg!(result)
-    // result = [
-    //     ComparedTextBlock {
-    //         id: "1",
-    //         text: "Hello world",
-    //         distance: 0.0,
-    //     },
-    //     ComparedTextBlock {
-    //         id: "2",
-    //         text: "Rust programming",
-    //         distance: 0.66691905,
-    //     },
-    // ]
+    println!("Similarity search results:");
+    for result in search_results {
+        println!("ID: {}, Text: {}, Distance: {}", result.id, result.text, result.distance);
+    }
+
+    // Get all text chunks from the database
+    let all_texts = embed_db.get_all_texts().await?;
+    println!("All texts: {:?}", all_texts);
+
+    // Delete texts by their IDs
+    let ids_to_delete = vec!["2".to_string(), "3".to_string()];
+    embed_db.delete_texts(&ids_to_delete).await?;
+
+    // Get the count of items in the database
+    let count = embed_db.items_count().await?;
+    println!("Number of items in the database: {}", count);
+
+    // Clear all data from the database
+    embed_db.empty_db().await?;
+
+    Ok(())
 }
 ```
+
+## Architecture
 
 EmbedStore encapsulates the Embedding engine and the VectorDb, providing a
 simple interface to store and query text blocks.


### PR DESCRIPTION
based on initial usage, I've tweaked the interface
- pub interface changes: See breaking changes
- rename TextBlock to TextChunk
- get_text_by_id now returns an `Option<TextChunk>` vs `Vec<TextChunk>`
- Added `///` doc blockes
- Improvements to README

BREAKING CHANGE: Public interface has changed
  - TextBlock --renamed--> TextChunk
  - get_text_by_id changed
  - Error struct added options
  - get_similar_to takes `&str` vs `TextChunk`