### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/samkeen/vec-embed-store/compare/v0.2.0...v0.3.0) - 2024-05-19
+
+### Fixed
+- [**breaking**] refactoring to interface
+
+### Other
+- Merge pull request [#10](https://github.com/samkeen/vec-embed-store/pull/10) from samkeen/finetune-interface
+
 ## [0.2.0](https://github.com/samkeen/vec-embed-store/compare/v0.1.1...v0.2.0) - 2024-05-18
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4444,7 +4444,7 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vec-embed-store"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "arrow-array",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vec-embed-store"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "This is a thin wrapper around LanceDb (VectorDb) meant to provide a means to create/store/query embeddings in a LanceDb without the need to grok the lower level Arrow/ColumnarDb tech."
 license = "Apache-2.0"


### PR DESCRIPTION
## 🤖 New release
* `vec-embed-store`: 0.2.0 -> 0.3.0 (⚠️ API breaking changes)

### ⚠️ `vec-embed-store` breaking changes

```
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.31.0/src/lints/enum_variant_added.ron

Failed in:
  variant EmbedDbError:EmbeddingsEngine in /tmp/.tmpsmxvUZ/vec-embed-store/src/lib.rs:570
  variant EmbedDbError:VectorDbEngine in /tmp/.tmpsmxvUZ/vec-embed-store/src/lib.rs:572
  variant EmbedDbError:InvalidState in /tmp/.tmpsmxvUZ/vec-embed-store/src/lib.rs:580

--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.31.0/src/lints/enum_variant_missing.ron

Failed in:
  variant EmbedDbError::Embedding, previously in file /tmp/.tmplHfz6W/vec-embed-store/src/lib.rs:384
  variant EmbedDbError::LanceDb, previously in file /tmp/.tmplHfz6W/vec-embed-store/src/lib.rs:386

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.31.0/src/lints/inherent_method_missing.ron

Failed in:
  EmbeddingsDb::get_table_names, previously in file /tmp/.tmplHfz6W/vec-embed-store/src/lib.rs:170

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.31.0/src/lints/struct_missing.ron

Failed in:
  struct vec_embed_store::TextBlock, previously in file /tmp/.tmplHfz6W/vec-embed-store/src/lib.rs:105
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.0](https://github.com/samkeen/vec-embed-store/compare/v0.2.0...v0.3.0) - 2024-05-19

### Fixed
- [**breaking**] refactoring to interface

### Other
- Merge pull request [#10](https://github.com/samkeen/vec-embed-store/pull/10) from samkeen/finetune-interface
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).