### PR TITLE
chore: release v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1](https://github.com/samkeen/vec-embed-store/compare/v0.3.0...v0.3.1) - 2024-06-13
+
+### Other
+- Merge pull request [#13](https://github.com/samkeen/vec-embed-store/pull/13) from samkeen/chore/update-dependencies
+- updated dependencies
+
 ## [0.3.0](https://github.com/samkeen/vec-embed-store/compare/v0.2.0...v0.3.0) - 2024-05-19
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4646,7 +4646,7 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vec-embed-store"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "arrow-array",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vec-embed-store"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 description = "This is a thin wrapper around LanceDb (VectorDb) meant to provide a means to create/store/query embeddings in a LanceDb without the need to grok the lower level Arrow/ColumnarDb tech."
 license = "Apache-2.0"


### PR DESCRIPTION
## 🤖 New release
* `vec-embed-store`: 0.3.0 -> 0.3.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.1](https://github.com/samkeen/vec-embed-store/compare/v0.3.0...v0.3.1) - 2024-06-13

### Other
- Merge pull request [#13](https://github.com/samkeen/vec-embed-store/pull/13) from samkeen/chore/update-dependencies
- updated dependencies
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).